### PR TITLE
Feature-fallback-to-url

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,1 +1,12 @@
+# .github/release.yml
 
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Changes
+      labels:
+        - "*"

--- a/foo_last_list_smp.js
+++ b/foo_last_list_smp.js
@@ -6,7 +6,7 @@ include('main\\last_list\\last_list_button.js');
 window.DefineScript("Last List",
     {
         author: "Ivo Barros",
-        version: "0.4",
+        version: "0.5",
     });
 
 const lastList = new _lastList();


### PR DESCRIPTION
When youtube element data is missing, we use the last.fm track url to build an artist name and track title. Allowing to match with user library even when no last.fm play button exists.