### PR TITLE
Revert back arguments to run method

### DIFF
--- a/scripts/LastList.js
+++ b/scripts/LastList.js
@@ -12,16 +12,16 @@ class LastList {
         this.cacheTime = cacheTime;
     }
 
-    run() {
-        try {
-            if (!this.url) {
+    run({ url = this.url, pages = this.pages, playlistName = this.playlistName, cacheTime = this.cacheTime } = {}) {
+        try { // In case an argument is set to null or '', the default value at constructor is used
+            if (!url) {
                 try {
-                    this.url = utils.InputBox(0, "Enter the URL:", "Download", '', true);
+                    url = utils.InputBox(0, "Enter the URL:", "Download", this.url, true);
                 } catch (e) {
                     throw new InputError('Canceled Input');
                 }
 
-                if (!this.url) {
+                if (!url) {
                     throw new InputError('No URL');
                 }
             }
@@ -29,7 +29,7 @@ class LastList {
             // if url has page as parameter, set directPage to true
             let regexPattern = /\/.*\?.*(page=(\d+))/gmi;
 
-            let matches = [...this.url.matchAll(regexPattern)];
+            let matches = [...url.matchAll(regexPattern)];
 
             let startPage = 1;
             if (matches.length > 0) {
@@ -38,35 +38,36 @@ class LastList {
                     startPage = 1;
                 }
 
-                this.url = this.url.replace(matches[0][1], "");
+                url = url.replace(matches[0][1], "");
             }
 
-            if (!this.pages || isNaN(this.pages) || this.pages < 1) {
+            if (!pages || isNaN(pages) || pages < 1) {
                 try {
-                    this.pages = utils.InputBox(0, "Enter the number of pages:", "Download", '1', true);
+                    pages = utils.InputBox(0, "Enter the number of pages:", "Download", this.pages, true);
                 } catch (e) {
                     throw new InputError('Canceled Input');
                 }
 
-                this.pages = parseInt(this.pages);
-                if (isNaN(this.pages) || this.pages < 1) {
-                    this.pages = 1;
+                pages = parseInt(pages);
+                if (isNaN(pages) || pages < 1) {
+                    pages = 1;
                 }
             }
 
-            if (!this.playlistName) {
+            if (!playlistName) {
                 try {
-                    this.playlistName = utils.InputBox(0, "Enter the playlist name:", "Download", 'Last List', true);
+                    playlistName = utils.InputBox(0, "Enter the playlist name:", "Download", this.playlistName, true);
                 } catch (e) {
                     throw new InputError('Canceled Input');
                 }
 
-                if (!this.playlistName) {
+                if (!playlistName) {
                     throw new InputError('No playlist name');
                 }
             }
 
-            this.scrapeUrl(this.url, startPage, this.pages, this.playlistName, this.cacheTime);
+            this.scrapeUrl(url, startPage, pages, playlistName, cacheTime);
+            this.url = url; // Cache
         } catch (e) {
             if (e instanceof InputError) {
                 // do nothing


### PR DESCRIPTION
Revert back arguments to run() method, and allow arguments caching in case they were set on the constructor and run is called with some argument set to null.

Now this doesn't change your current code logic, but allows proper usage of run method.
```
const lfm = LastList({url: 'myweb')
// This will show a popup but using 'myweb' as prefilled value
lfm.run({url: null});
// This will not show a popup and just use 'myweb'
lfm.run();
// This will not show a popup, use 'my other web', and set such value as this.url to be reused on later call
lfm.run({url: 'my other web'});
// This will not show a popup and use 'my other web' now
lfm.run();
```
You have to obviously stop using the constructor to set arguments on every of your menu calls if you want the custom url to be cached. Just construct once and use run.

![lastlist2](https://user-images.githubusercontent.com/83307074/223799953-06a19fcd-a839-403a-945f-c6192085c635.gif)